### PR TITLE
feat: 新增 MCP 管理与软件自更新功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 .sisyphus/
 .omo/
 .codegraph/
+
+# 运行时生成文件（含用户配置，不应提交）
+*.exe.old
+update/
+mcp_servers.json

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,8 +7,8 @@ use crate::engine::server::{ServerManager, ServerState};
 use crate::i18n::{self, Language};
 use crate::spacing_debugger::SpacingDebugger;
 use crate::ui::{
-    launch_commands_panel, log_panel, model_panel, params_panel, presets_panel, rpc_panel,
-    server_panel, settings_panel, widgets,
+    launch_commands_panel, log_panel, mcp_panel, model_panel, params_panel, presets_panel,
+    rpc_panel, server_panel, settings_panel, widgets,
 };
 use egui::Color32;
 
@@ -19,6 +19,7 @@ enum NavSection {
     Rpc,
     Model,
     Params,
+    Mcp,
     Log,
     RpcLog,
     Commands,
@@ -32,6 +33,8 @@ pub struct LlamaLauncherApp {
     server_manager: ServerManager,
     rpc_manager: RpcManager,
     downloader: DownloadHandle,
+    updater: crate::updater::UpdaterHandle,
+    install_exit_timer: f32, // 自更新安装阶段：显示"正在安装"的倒计时
     nav: NavSection,
     logo: Option<egui::TextureHandle>,
     theme_applied: (bool, String),
@@ -133,6 +136,8 @@ impl LlamaLauncherApp {
             server_manager,
             rpc_manager,
             downloader: DownloadHandle::new(),
+            updater: crate::updater::UpdaterHandle::new(),
+            install_exit_timer: 0.0,
             nav: NavSection::Server,
             logo,
             theme_applied: (true, String::new()), // 重新应用逻辑在 update 中处理
@@ -350,6 +355,11 @@ impl LlamaLauncherApp {
                         i18n::t(i18n::Key::TabParams, &self.lang),
                     ),
                     (
+                        NavSection::Mcp,
+                        widgets::NavIcon::Mcp,
+                        i18n::t(i18n::Key::TabMcp, &self.lang),
+                    ),
+                    (
                         NavSection::Log,
                         widgets::NavIcon::Log,
                         i18n::t(i18n::Key::TabLog, &self.lang),
@@ -392,6 +402,7 @@ impl LlamaLauncherApp {
             NavSection::Rpc => i18n::t(i18n::Key::NavRpc, &self.lang),
             NavSection::Model => i18n::t(i18n::Key::TabModel, &self.lang),
             NavSection::Params => i18n::t(i18n::Key::TabParams, &self.lang),
+            NavSection::Mcp => i18n::t(i18n::Key::TabMcp, &self.lang),
             NavSection::Log => i18n::t(i18n::Key::TabLog, &self.lang),
             NavSection::RpcLog => i18n::t(i18n::Key::TabRpcLog, &self.lang),
             NavSection::Commands => i18n::t(i18n::Key::TabCommands, &self.lang),
@@ -470,6 +481,19 @@ impl LlamaLauncherApp {
 impl eframe::App for LlamaLauncherApp {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         ctx.request_repaint_after(std::time::Duration::from_millis(500));
+
+        // 自更新安装阶段：下载完成并启动自替换脚本后，短暂展示"正在安装"再关闭窗口
+        // （Let 脚本等待主进程退出）
+        if matches!(
+            self.updater.snapshot().state,
+            crate::updater::UpdateState::Installing
+        ) {
+            self.install_exit_timer += ctx.input(|i| i.stable_dt);
+            if self.install_exit_timer > 1.5 {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                return;
+            }
+        }
 
         // 根据调试模式开关，控制 egui Inspector（悬浮时显示内置检查器面板）
         #[cfg(debug_assertions)]
@@ -600,6 +624,7 @@ impl eframe::App for LlamaLauncherApp {
                             NavSection::Params => {
                                 params_panel::ui(ui, &mut self.settings, &self.lang)
                             }
+                            NavSection::Mcp => mcp_panel::ui(ui, &mut self.settings, &self.lang),
                             NavSection::Log => log_panel::ui(
                                 ui,
                                 &mut self.settings,
@@ -633,6 +658,7 @@ impl eframe::App for LlamaLauncherApp {
                                 &self.lang,
                                 &mut self.show_about,
                                 &mut self.debug_mode,
+                                &self.updater,
                             ),
                         });
                 });
@@ -650,6 +676,7 @@ impl Drop for LlamaLauncherApp {
         self.server_manager.stop();
         self.rpc_manager.stop();
         self.downloader.request_cancel();
+        self.updater.request_cancel();
         self.save();
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -574,6 +574,12 @@ pub struct Preset {
     pub chat_template: String, // --chat-template（Jinja 模板文本）
     #[serde(default)]
     pub chat_template_file: PathBuf, // --chat-template-file（Jinja 模板文件）
+
+    // MCP 管理（llama.cpp --mcp-servers-config）
+    #[serde(default)]
+    pub mcp_enabled: bool, // MCP 功能总开关（无启用 server 时不拼接参数）
+    #[serde(default)]
+    pub mcp_server_states: std::collections::BTreeMap<String, bool>, // 每个 MCP server 的启用状态（按名称）
 }
 
 impl Default for Preset {
@@ -670,6 +676,8 @@ impl Default for Preset {
             jinja_enabled: default_jinja_enabled(),
             chat_template: String::new(),
             chat_template_file: PathBuf::new(),
+            mcp_enabled: false,
+            mcp_server_states: std::collections::BTreeMap::new(),
         }
     }
 }
@@ -769,6 +777,8 @@ impl Preset {
             jinja_enabled: settings.jinja_enabled,
             chat_template: settings.chat_template.clone(),
             chat_template_file: settings.chat_template_file.clone(),
+            mcp_enabled: settings.mcp_enabled,
+            mcp_server_states: settings.mcp_server_states.clone(),
         }
     }
 
@@ -872,6 +882,9 @@ impl Preset {
         settings.jinja_enabled = self.jinja_enabled;
         settings.chat_template = self.chat_template;
         settings.chat_template_file = self.chat_template_file;
+        // MCP 管理（原始 JSON 不属于 Preset，仅同步启用状态）
+        settings.mcp_enabled = self.mcp_enabled;
+        settings.mcp_server_states = self.mcp_server_states;
     }
 }
 
@@ -1104,6 +1117,24 @@ pub struct AppSettings {
     #[serde(default)]
     pub chat_template_file: PathBuf, // --chat-template-file（Jinja 模板文件）
 
+    // MCP 管理（llama.cpp --mcp-servers-config）
+    #[serde(default)]
+    pub mcp_enabled: bool, // MCP 功能总开关（无启用 server 时不拼接参数）
+    #[serde(default)]
+    pub mcp_server_states: std::collections::BTreeMap<String, bool>, // 每个 MCP server 的启用状态（按名称）
+
+    // 用户原始 MCP 配置（Cursor-compatible mcpServers JSON 文本，仅全局设置，不进 Preset）
+    #[serde(default)]
+    pub mcp_config_json: String,
+
+    // MCP 配置编辑器 UI 状态（不序列化）
+    #[serde(skip, default)]
+    pub mcp_editor_open: bool,
+    #[serde(skip, default)]
+    pub mcp_editor_text: String,
+    #[serde(skip, default)]
+    pub mcp_editor_error: String,
+
     // 预设
     #[serde(default)]
     pub presets: Vec<Preset>,
@@ -1279,6 +1310,12 @@ impl Default for AppSettings {
             jinja_enabled: default_jinja_enabled(),
             chat_template: String::new(),
             chat_template_file: PathBuf::new(),
+            mcp_enabled: false,
+            mcp_server_states: std::collections::BTreeMap::new(),
+            mcp_config_json: String::new(),
+            mcp_editor_open: false,
+            mcp_editor_text: String::new(),
+            mcp_editor_error: String::new(),
             presets: Vec::new(),
             new_preset_name: String::new(),
             rename_preset_index: None,
@@ -1312,6 +1349,126 @@ impl AppSettings {
     pub fn ubatch_size_actual(&self) -> usize {
         (self.ubatch_size * 1024.0) as usize
     }
+
+    /// 构造"当前启用"的 MCP 配置 JSON（纯逻辑，便于测试）。
+    ///
+    /// 规则（对齐 llama.cpp tools/server/server-mcp.cpp 的解析行为）：
+    /// - 未开启 MCP / 无原始配置 / JSON 非法 / 无启用的 server → 返回 None（不拼接参数）
+    /// - 只保留处于启用状态且带非空 `command`（stdio 型）的 server
+    pub fn build_effective_mcp_json(&self) -> Option<serde_json::Value> {
+        if !self.mcp_enabled || self.mcp_config_json.trim().is_empty() {
+            return None;
+        }
+        let root: serde_json::Value = match serde_json::from_str(&self.mcp_config_json) {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("[mcp] 配置 JSON 解析失败，跳过 MCP 参数: {}", e);
+                return None;
+            }
+        };
+        let servers = match root.get("mcpServers").and_then(|v| v.as_object()) {
+            Some(s) => s,
+            None => {
+                log::warn!("[mcp] 配置缺少 mcpServers 对象，跳过 MCP 参数");
+                return None;
+            }
+        };
+        let mut effective = serde_json::Map::new();
+        for (name, cfg) in servers {
+            let enabled = self.mcp_server_states.get(name).copied().unwrap_or(false);
+            let has_command = cfg
+                .get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(|c| !c.is_empty());
+            if enabled && has_command {
+                effective.insert(name.clone(), cfg.clone());
+            }
+        }
+        if effective.is_empty() {
+            return None;
+        }
+        Some(serde_json::json!({ "mcpServers": effective }))
+    }
+
+    /// 生成"当前启用的 MCP 配置文件"并返回其路径
+    /// （写入 launcher exe 同目录 `mcp_servers.json`，与 llama_cpp_launcher_settings.json 同级）。
+    /// 无启用 server 或生成失败时返回 None（不拼接参数）。
+    pub fn write_effective_mcp_config(&self) -> Option<PathBuf> {
+        let out = self.build_effective_mcp_json()?;
+        let dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
+        let path = dir.join("mcp_servers.json");
+        let content = serde_json::to_string_pretty(&out).unwrap_or_default();
+        match std::fs::write(&path, content) {
+            Ok(_) => Some(path),
+            Err(e) => {
+                log::warn!("[mcp] 写入 MCP 配置文件失败: {}", e);
+                None
+            }
+        }
+    }
+}
+
+/// MCP server 概要（供 UI 列表展示，由 parse_mcp_servers 解析）
+#[derive(Debug, Clone)]
+pub struct McpServerSummary {
+    pub name: String,
+    /// stdio 启动命令；为空表示该条目 llama.cpp 无法启动（会被其跳过）
+    pub command: String,
+    pub args: Vec<String>,
+    pub timeout_ms: i64,
+    /// 条目本身是否为合法 JSON object
+    pub is_object: bool,
+}
+
+/// 解析用户提供的 Cursor-compatible mcpServers JSON，返回 server 概要列表（保持 JSON 顺序）。
+///
+/// 错误情况（返回 Err 描述）：
+/// - JSON 非法
+/// - 顶层不是 object
+/// - 缺少 `mcpServers` 或其不是 object
+pub fn parse_mcp_servers(json_text: &str) -> Result<Vec<McpServerSummary>, String> {
+    let root: serde_json::Value =
+        serde_json::from_str(json_text).map_err(|e| format!("JSON: {}", e))?;
+    let root_obj = root
+        .as_object()
+        .ok_or_else(|| "top-level must be an object".to_string())?;
+    let servers = root_obj
+        .get("mcpServers")
+        .ok_or_else(|| "missing \"mcpServers\"".to_string())?;
+    let servers = servers
+        .as_object()
+        .ok_or_else(|| "\"mcpServers\" must be an object".to_string())?;
+
+    let mut result = Vec::new();
+    for (name, cfg) in servers {
+        let is_object = cfg.is_object();
+        let command = cfg
+            .get("command")
+            .and_then(|c| c.as_str())
+            .unwrap_or("")
+            .to_string();
+        let args = cfg
+            .get("args")
+            .and_then(|a| a.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let timeout_ms = cfg
+            .get("timeout_ms")
+            .and_then(|t| t.as_i64())
+            .unwrap_or(30000);
+        result.push(McpServerSummary {
+            name: name.clone(),
+            command,
+            args,
+            timeout_ms,
+            is_object,
+        });
+    }
+    Ok(result)
 }
 
 pub struct SettingsManager {
@@ -1536,5 +1693,92 @@ mod tests {
         let json = r#"{"server_path":"","host":"127.0.0.1","port":8080,"parallel_slots":1,"model_path":"","mmproj_path":"","temperature":0.8,"top_p":0.95,"top_k":40,"repeat_penalty":1.1,"presence_penalty":0.0,"kv_offload":false,"cache_type_k":"f16","cache_type_v":"f16","kv_mlock":false,"kv_mmap":true,"kv_unified":false,"gpu_layers_mode":"auto","split_mode":"none","tensor_split":"","cpu_moe":false,"n_cpu_moe":0,"rpc_server_path":"","rpc_host":"127.0.0.1","rpc_port":50052,"rpc_threads":8,"rpc_device":"","rpc_cache":false,"verbose":false}"#;
         let settings: AppSettings = serde_json::from_str(json).expect("旧格式配置应可反序列化");
         assert_eq!(settings.download_variant, "cpu");
+    }
+
+    // ──── MCP 解析 / 生效配置 ────
+
+    const MCP_TEST_JSON: &str = r#"{
+        "mcpServers": {
+            "comfyui": {
+                "command": "python",
+                "args": ["C:\\AI\\MCP\\ComfyUI\\server.py"]
+            },
+            "filesystem": {
+                "command": "npx",
+                "args": ["-y", "@example/filesystem-mcp"],
+                "timeout_ms": 60000
+            },
+            "remote-only": {
+                "url": "https://example.com/mcp"
+            }
+        }
+    }"#;
+
+    /// 正常解析：提取全部 server 名称与关键字段，无 command 条目标记
+    #[test]
+    fn mcp_parse_ok() {
+        let servers = parse_mcp_servers(MCP_TEST_JSON).expect("合法配置应解析成功");
+        assert_eq!(servers.len(), 3);
+        assert_eq!(servers[0].name, "comfyui");
+        assert_eq!(servers[0].command, "python");
+        assert_eq!(servers[0].args, vec!["C:\\AI\\MCP\\ComfyUI\\server.py"]);
+        assert_eq!(servers[1].timeout_ms, 60000);
+        assert!(
+            servers[2].command.is_empty(),
+            "无 command 条目应为空 command"
+        );
+    }
+
+    /// 错误场景：非法 JSON / 顶层非对象 / 缺 mcpServers / mcpServers 非 object
+    #[test]
+    fn mcp_parse_errors() {
+        assert!(parse_mcp_servers("{ not json").is_err());
+        assert!(parse_mcp_servers("[1,2]").is_err());
+        assert!(parse_mcp_servers(r#"{"foo":{}}"#).is_err());
+        assert!(parse_mcp_servers(r#"{"mcpServers":[1]}"#).is_err());
+        // 空 mcpServers 合法（返回空列表）
+        assert!(parse_mcp_servers(r#"{"mcpServers":{}}"#)
+            .expect("空对象应成功")
+            .is_empty());
+    }
+
+    /// 生效配置：只保留启用且带 command 的 server；无启用时返回 None
+    #[test]
+    fn mcp_effective_partial_enable() {
+        let mut settings = AppSettings::default();
+        settings.mcp_enabled = true;
+        settings.mcp_config_json = MCP_TEST_JSON.to_string();
+        // 无任何启用 → None
+        assert!(settings.build_effective_mcp_json().is_none());
+        // 只启用 comfyui（stdio）与 remote-only（无 command，应被过滤）
+        settings
+            .mcp_server_states
+            .insert("comfyui".to_string(), true);
+        settings
+            .mcp_server_states
+            .insert("remote-only".to_string(), true);
+        let out = settings
+            .build_effective_mcp_json()
+            .expect("存在启用的 stdio server");
+        let servers = out
+            .get("mcpServers")
+            .and_then(|v| v.as_object())
+            .expect("输出应含 mcpServers 对象");
+        assert_eq!(servers.len(), 1, "remote-only 应被过滤");
+        assert!(servers.contains_key("comfyui"));
+        // 总开关关闭 → None
+        settings.mcp_enabled = false;
+        assert!(settings.build_effective_mcp_json().is_none());
+    }
+
+    /// 旧配置兼容：缺少 MCP 字段的配置反序列化后为默认值
+    #[test]
+    fn mcp_settings_default_compat() {
+        let json = r#"{"server_path":"","host":"127.0.0.1","port":8080,"parallel_slots":1,"model_path":"","mmproj_path":"","temperature":0.8,"top_p":0.95,"top_k":40,"repeat_penalty":1.1,"presence_penalty":0.0,"kv_offload":false,"cache_type_k":"f16","cache_type_v":"f16","kv_mlock":false,"kv_mmap":true,"kv_unified":false,"gpu_layers_mode":"auto","split_mode":"none","tensor_split":"","cpu_moe":false,"n_cpu_moe":0,"rpc_server_path":"","rpc_host":"127.0.0.1","rpc_port":50052,"rpc_threads":8,"rpc_device":"","rpc_cache":false,"verbose":false}"#;
+        let settings: AppSettings = serde_json::from_str(json).expect("旧格式配置应可反序列化");
+        assert!(!settings.mcp_enabled);
+        assert!(settings.mcp_config_json.is_empty());
+        assert!(settings.mcp_server_states.is_empty());
+        assert!(settings.build_effective_mcp_json().is_none());
     }
 }

--- a/src/engine/server.rs
+++ b/src/engine/server.rs
@@ -555,6 +555,12 @@ impl ServerManager {
             cmd.arg("--no-webui");
         }
 
+        // MCP 工具：生成"当前启用"的 MCP 配置文件并传给 llama-server
+        // （无启用 server 或生成失败时函数返回 None，不拼接参数）
+        if let Some(mcp_config_path) = settings.write_effective_mcp_config() {
+            cmd.arg("--mcp-servers-config").arg(&mcp_config_path);
+        }
+
         // API 安全 / 部署（空值不拼接）
         if !settings.api_key.is_empty() {
             cmd.arg("--api-key").arg(&settings.api_key);

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -28,10 +28,25 @@ pub enum Key {
     TabRpc,
     TabModel,
     TabParams,
+    TabMcp,
     TabLog,
     TabRpcLog,
     TabCommands,
     TabPresets,
+
+    // MCP 管理面板
+    SectionMcpSettings,
+    CheckboxMcpEnabled,
+    BtnEditMcpConfig,
+    HintMcpTip,
+    SectionMcpServers,
+    HintMcpEntryInvalid,
+    HintMcpUnsupported,
+    TitleMcpEditor,
+    HintMcpEditorTip,
+    BtnMcpSave,
+    BtnMcpCancel,
+    ErrMcpConfigInvalid,
 
     // 侧边栏导航（中文优先）
     NavServer,
@@ -328,6 +343,16 @@ pub enum Key {
     AboutDescription,
     AboutCopyright,
 
+    // 自更新（软件本身；检查更新按钮复用上游 BtnCheckUpdate）
+    BtnInstallUpdate,
+    UpdChecking,
+    UpdLatest,
+    UpdAvailable,
+    UpdDownloading,
+    UpdInstalling,
+    UpdError,
+    UpdNetworkError,
+
     // 菜单 - 项目地址
     MenuItemRepo,
 
@@ -473,6 +498,34 @@ impl Key {
             (Key::TabModel, &Language::En) => "Model",
             (Key::TabParams, &Language::Zh) => "参数",
             (Key::TabParams, &Language::En) => "Params",
+            (Key::TabMcp, &Language::Zh) => "MCP 管理",
+            (Key::TabMcp, &Language::En) => "MCP",
+
+            // MCP 管理面板
+            (Key::SectionMcpSettings, &Language::Zh) => "MCP 设置",
+            (Key::SectionMcpSettings, &Language::En) => "MCP Settings",
+            (Key::CheckboxMcpEnabled, &Language::Zh) => "启用 MCP 工具 (--mcp-servers-config)",
+            (Key::CheckboxMcpEnabled, &Language::En) => "Enable MCP tools (--mcp-servers-config)",
+            (Key::BtnEditMcpConfig, &Language::Zh) => "编辑配置",
+            (Key::BtnEditMcpConfig, &Language::En) => "Edit Config",
+            (Key::HintMcpTip, &Language::Zh) => "读取已有的 Cursor-compatible mcpServers 配置，按需启用后随 llama-server 启动",
+            (Key::HintMcpTip, &Language::En) => "Load your existing Cursor-compatible mcpServers config and pass enabled servers to llama-server",
+            (Key::SectionMcpServers, &Language::Zh) => "MCP Servers",
+            (Key::SectionMcpServers, &Language::En) => "MCP Servers",
+            (Key::HintMcpEntryInvalid, &Language::Zh) => "配置条目不是对象，llama.cpp 将跳过",
+            (Key::HintMcpEntryInvalid, &Language::En) => "Entry is not an object; llama.cpp will skip it",
+            (Key::HintMcpUnsupported, &Language::Zh) => "不含 command（非 stdio 型），llama.cpp 当前仅支持 stdio，将跳过",
+            (Key::HintMcpUnsupported, &Language::En) => "No command (non-stdio); llama.cpp only supports stdio and will skip it",
+            (Key::TitleMcpEditor, &Language::Zh) => "编辑 MCP 配置",
+            (Key::TitleMcpEditor, &Language::En) => "Edit MCP Config",
+            (Key::HintMcpEditorTip, &Language::Zh) => "支持 Cursor-compatible mcpServers JSON",
+            (Key::HintMcpEditorTip, &Language::En) => "Cursor-compatible mcpServers JSON",
+            (Key::BtnMcpSave, &Language::Zh) => "保存",
+            (Key::BtnMcpSave, &Language::En) => "Save",
+            (Key::BtnMcpCancel, &Language::Zh) => "取消",
+            (Key::BtnMcpCancel, &Language::En) => "Cancel",
+            (Key::ErrMcpConfigInvalid, &Language::Zh) => "配置无效：",
+            (Key::ErrMcpConfigInvalid, &Language::En) => "Invalid config:",
 
             (Key::TabLog, &Language::Zh) => "服务器日志",
             (Key::TabLog, &Language::En) => "Server Logs",
@@ -1038,6 +1091,23 @@ impl Key {
             (Key::AboutCopyright, &Language::Zh) => "© yihuishou. All rights reserved.",
             (Key::AboutCopyright, &Language::En) => "© yihuishou. All rights reserved.",
 
+            // 自更新（软件本身）
+            (Key::BtnInstallUpdate, &Language::Zh) => "安装更新",
+            (Key::BtnInstallUpdate, &Language::En) => "Install Update",
+            (Key::UpdChecking, &Language::Zh) => "正在检查更新…",
+            (Key::UpdChecking, &Language::En) => "Checking for updates…",
+            (Key::UpdLatest, &Language::Zh) => "已是最新版本",
+            (Key::UpdLatest, &Language::En) => "Up to date",
+            (Key::UpdAvailable, &Language::Zh) => "发现新版本",
+            (Key::UpdAvailable, &Language::En) => "New version available",
+            (Key::UpdDownloading, &Language::Zh) => "正在下载更新",
+            (Key::UpdDownloading, &Language::En) => "Downloading update",
+            (Key::UpdInstalling, &Language::Zh) => "正在安装，即将重启…",
+            (Key::UpdInstalling, &Language::En) => "Installing, restarting…",
+            (Key::UpdError, &Language::Zh) => "更新失败",
+            (Key::UpdError, &Language::En) => "Update failed",
+            (Key::UpdNetworkError, &Language::Zh) => "获取失败：网络错误",
+            (Key::UpdNetworkError, &Language::En) => "Failed: network error",
 
             // Server 面板 - 版本
             (Key::BtnCheckVersion, &Language::Zh) => "查看 llama.cpp 版本",

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ pub mod shortcut;
 mod spacing_debugger;
 pub mod theme;
 pub mod ui;
+pub mod updater;
 
 use chrono::Local;
 use log::{LevelFilter, Log, Metadata, Record};

--- a/src/ui/log_panel.rs
+++ b/src/ui/log_panel.rs
@@ -84,7 +84,8 @@ fn render(
             // 任何微差都会触发外层垂直滚动条（同 presets 空态问题），
             // 且滚动条占宽后日志换行加高，锁存持续显示。
             let max_h = (ui.available_height() - 18.0).max(64.0);
-            egui::ScrollArea::vertical()
+            let mut viewport_rect = egui::Rect::NOTHING;
+            let scroll_output = egui::ScrollArea::vertical()
                 .auto_shrink(false)
                 .max_height(max_h)
                 .id_salt(scroll_salt)
@@ -100,7 +101,6 @@ fn render(
                         logs.drain(..start_index);
                     }
 
-                    let text_color = ui.visuals().text_color();
                     if logs.is_empty() {
                         ui.add_space(8.0);
                         ui.horizontal_centered(|ui| {
@@ -110,35 +110,76 @@ fn render(
                             );
                         });
                     } else {
+                        // ★ 整块日志合并为单一 LayoutJob 文本（Label 选择器）：
+                        // egui 的文本选择只在单个 widget 内有效，逐行 label 无法跨行选择；
+                        // 合并后按级别着色保持不变，且拖选可跨任意行延伸。
+                        let mut job = egui::text::LayoutJob::default();
+                        let text_color = ui.visuals().text_color();
                         for entry in &logs {
-                            let prefix = match entry.level {
-                                LogLevel::Info => "",
-                                LogLevel::Warn => "⚠ ",
-                                LogLevel::Error => "✖ ",
+                            let (prefix, color) = match entry.level {
+                                LogLevel::Info => ("", text_color),
+                                LogLevel::Warn => ("⚠ ", egui::Color32::YELLOW),
+                                LogLevel::Error => ("✖ ", egui::Color32::RED),
                             };
-                            let text = format!("{}{}", prefix, entry.text);
-                            ui.horizontal_wrapped(|ui| match entry.level {
-                                LogLevel::Info => {
-                                    ui.colored_label(text_color, &text);
-                                }
-                                LogLevel::Warn => {
-                                    egui::Frame::default()
-                                        .fill(egui::Color32::from_rgb(80, 80, 80))
-                                        .inner_margin(egui::Margin::same(4))
-                                        .corner_radius(6.0)
-                                        .show(ui, |ui| {
-                                            ui.colored_label(egui::Color32::YELLOW, &text);
-                                        });
-                                }
-                                LogLevel::Error => {
-                                    ui.colored_label(egui::Color32::RED, &text);
-                                }
-                            });
+                            let line = format!("{}{}\n", prefix, entry.text);
+                            job.append(
+                                &line,
+                                0.0,
+                                egui::TextFormat::simple(egui::FontId::default(), color),
+                            );
                         }
+                        ui.add(egui::Label::new(job).selectable(true));
                     }
+                    viewport_rect = ui.clip_rect();
                 });
+
+            // ★ 拖选越界自动滚动（egui 无内置）：按住左键拖选时指针越过视口
+            //   上/下边缘，则持续推进滚动偏移，使选区向该方向扩展。
+            //   注：egui 在拖拽中本身仍响应滚轮（ScrollArea 滚轮不依赖拖拽状态），
+            //   合并单 widget 后"按住选择 + 滚轮"即可延伸选区，无需额外处理。
+            auto_scroll_on_drag(ui.ctx(), scroll_output.id, viewport_rect);
         }
     });
+}
+
+/// 按住左键拖选时，指针接近/越过日志视口上下边缘 → 按比例推进滚动偏移。
+/// 直接改写 ScrollArea State 的公开 offset 字段（每帧调用形成连续滚动）。
+/// 仅在用户关闭「自动滚动」时影响实际位置；开启 stick_to_bottom 时
+/// egui 会在每帧末尾把偏移拉回底部（拖选本就不适合在 stick 模式下进行）。
+fn auto_scroll_on_drag(ctx: &egui::Context, scroll_state_id: egui::Id, viewport: egui::Rect) {
+    if viewport == egui::Rect::NOTHING {
+        return;
+    }
+    let Some(pointer) = ctx.input(|i| i.pointer.interact_pos()) else {
+        return;
+    };
+    let dragging = ctx.input(|i| i.pointer.primary_down() && i.pointer.is_decidedly_dragging());
+    if !dragging {
+        return;
+    }
+
+    const EDGE: f32 = 32.0; // 视口上下边缘的触发带高度
+    const SPEED: f32 = 18.0; // 每帧最大推进像素
+                             // 指针允许略微越过视口（最多 96px）仍视为在拖选本区域
+    const OVERSHOOT: f32 = 96.0;
+
+    let mut dy = 0.0;
+    if pointer.y < viewport.top() + EDGE && pointer.y > viewport.top() - OVERSHOOT {
+        // 越接近/越过上边缘，速度越快（0..1 线性）
+        let t = ((viewport.top() + EDGE - pointer.y) / EDGE).clamp(0.0, 1.0);
+        dy = -SPEED * t;
+    } else if pointer.y > viewport.bottom() - EDGE && pointer.y < viewport.bottom() + OVERSHOOT {
+        let t = ((pointer.y - (viewport.bottom() - EDGE)) / EDGE).clamp(0.0, 1.0);
+        dy = SPEED * t;
+    }
+    if dy == 0.0 {
+        return;
+    }
+
+    if let Some(mut state) = egui::scroll_area::State::load(ctx, scroll_state_id) {
+        state.offset.y = (state.offset.y + dy).max(0.0);
+        state.store(ctx, scroll_state_id);
+    }
 }
 
 /// 服务器日志面板（原「运行日志」，已改名）

--- a/src/ui/mcp_panel.rs
+++ b/src/ui/mcp_panel.rs
@@ -1,0 +1,235 @@
+use crate::config::settings::{parse_mcp_servers, AppSettings};
+use crate::i18n;
+use crate::ui::widgets;
+
+/// MCP 管理面板：
+/// 读取用户已有的 Cursor-compatible mcpServers 配置 → 可视化 → 启用/禁用 →
+/// 启动 llama-server 时由 ServerManager 生成"当前启用"配置并拼接 --mcp-servers-config。
+/// 本面板不安装/下载/部署 MCP，也不管理 MCP 进程生命周期（由 llama-server 官方机制处理）。
+pub fn ui(ui: &mut egui::Ui, settings: &mut AppSettings, lang: &i18n::Language) {
+    let accent = crate::theme::accent_color(&settings.accent_color);
+
+    // 解析当前配置（失败时在设置卡片中提示，不阻塞页面）
+    let parsed = parse_mcp_servers(&settings.mcp_config_json);
+
+    // ── MCP 设置 ──
+    widgets::card(
+        ui,
+        i18n::t(i18n::Key::SectionMcpSettings, lang),
+        accent,
+        |ui| {
+            ui.horizontal(|ui| {
+                widgets::toggle(
+                    ui,
+                    &mut settings.mcp_enabled,
+                    i18n::t(i18n::Key::CheckboxMcpEnabled, lang),
+                    accent,
+                );
+            });
+            ui.horizontal(|ui| {
+                if ui
+                    .button(i18n::t(i18n::Key::BtnEditMcpConfig, lang))
+                    .clicked()
+                {
+                    settings.mcp_editor_text = settings.mcp_config_json.clone();
+                    settings.mcp_editor_error.clear();
+                    settings.mcp_editor_open = true;
+                }
+                // 状态摘要：已启用 x/y，或配置错误提示
+                match &parsed {
+                    Ok(servers) if !servers.is_empty() => {
+                        let enabled = servers
+                            .iter()
+                            .filter(|s| {
+                                settings
+                                    .mcp_server_states
+                                    .get(&s.name)
+                                    .copied()
+                                    .unwrap_or(false)
+                            })
+                            .count();
+                        ui.small(format!("{}/{}", enabled, servers.len()));
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        ui.small(
+                            egui::RichText::new(format!(
+                                "{} {}",
+                                i18n::t(i18n::Key::ErrMcpConfigInvalid, lang),
+                                e
+                            ))
+                            .color(ui.visuals().error_fg_color),
+                        );
+                    }
+                }
+            });
+            ui.small(i18n::t(i18n::Key::HintMcpTip, lang));
+        },
+    );
+
+    // ── MCP Servers 列表 ──
+    if let Ok(servers) = &parsed {
+        if !servers.is_empty() {
+            widgets::card(
+                ui,
+                i18n::t(i18n::Key::SectionMcpServers, lang),
+                accent,
+                |ui| {
+                    for s in servers {
+                        ui.horizontal(|ui| {
+                            // ★ 开关在左、名称在右（与项目 toggle 行样式一致）
+                            let state = settings
+                                .mcp_server_states
+                                .entry(s.name.clone())
+                                .or_insert(false);
+                            widgets::toggle(ui, state, "", accent);
+                            // 不用裸 .strong()：浅色模式下 strong_text_color=白色会隐形，显式指定主文本色
+                            ui.label(
+                                egui::RichText::new(&s.name)
+                                    .color(ui.visuals().text_color())
+                                    .strong(),
+                            );
+                        });
+                        // 摘要行：command args… / timeout；无 command 的条目给出明确不支持提示
+                        ui.indent(format!("mcp_summary_{}", s.name), |ui| {
+                            if !s.is_object {
+                                ui.small(
+                                    egui::RichText::new(i18n::t(
+                                        i18n::Key::HintMcpEntryInvalid,
+                                        lang,
+                                    ))
+                                    .color(ui.visuals().error_fg_color),
+                                );
+                            } else if s.command.is_empty() {
+                                ui.small(
+                                    egui::RichText::new(i18n::t(
+                                        i18n::Key::HintMcpUnsupported,
+                                        lang,
+                                    ))
+                                    .color(ui.visuals().warn_fg_color),
+                                );
+                            } else {
+                                let mut summary = s.command.clone();
+                                if !s.args.is_empty() {
+                                    summary.push(' ');
+                                    summary.push_str(&s.args.join(" "));
+                                }
+                                ui.horizontal(|ui| {
+                                    ui.small(
+                                        egui::RichText::new(summary)
+                                            .color(ui.visuals().weak_text_color()),
+                                    );
+                                    ui.small(
+                                        egui::RichText::new(format!("({} ms)", s.timeout_ms))
+                                            .color(ui.visuals().weak_text_color()),
+                                    );
+                                });
+                            }
+                        });
+                        ui.add_space(4.0);
+                    }
+                },
+            );
+        }
+    }
+
+    // ── 配置编辑弹窗 ──
+    editor_window(ui.ctx(), settings, lang);
+}
+
+/// MCP 配置编辑窗口：多行文本编辑 + JSON 校验 + 保存/取消
+/// （open 状态经局部变量中转，避免 Window::open 与闭包同时借用 settings）
+///
+/// 布局（egui 标准弹窗规范）：
+/// - 窗口尺寸约束在屏幕 90% 以内，内容超长时编辑区内部滚动，
+///   保存/取消按钮固定在底部永远可达；
+/// - 传入显式 Frame 使标题栏颜色与内容区一致（默认标题栏用
+///   widgets.open.weak_bg_fill，深色模式下与 window_fill 有色差）。
+fn editor_window(ctx: &egui::Context, settings: &mut AppSettings, lang: &i18n::Language) {
+    if !settings.mcp_editor_open {
+        return;
+    }
+    let mut open = true;
+    let mut close_after_save = false;
+    let screen = ctx.content_rect().size();
+    let style = ctx.style();
+    egui::Window::new(i18n::t(i18n::Key::TitleMcpEditor, lang))
+        .open(&mut open)
+        .resizable(true)
+        .default_width(520.0)
+        .default_height(420.0)
+        .min_width(360.0)
+        .min_height(240.0)
+        .max_width(screen.x * 0.9)
+        .max_height(screen.y * 0.9)
+        .frame(egui::Frame::window(&style))
+        .show(ctx, |ui| {
+            ui.small(i18n::t(i18n::Key::HintMcpEditorTip, lang));
+
+            if !settings.mcp_editor_error.is_empty() {
+                ui.add_space(4.0);
+                ui.small(
+                    egui::RichText::new(format!(
+                        "{} {}",
+                        i18n::t(i18n::Key::ErrMcpConfigInvalid, lang),
+                        settings.mcp_editor_error
+                    ))
+                    .color(ui.visuals().error_fg_color),
+                );
+            }
+
+            // 底部按钮面板：先于中央区渲染，固定占据底部（保存/取消永远可见）
+            egui::TopBottomPanel::bottom("mcp_editor_buttons")
+                .frame(egui::Frame::NONE)
+                .show_inside(ui, |ui| {
+                    ui.add_space(6.0);
+                    ui.horizontal(|ui| {
+                        if ui.button(i18n::t(i18n::Key::BtnMcpSave, lang)).clicked() {
+                            match parse_mcp_servers(&settings.mcp_editor_text) {
+                                Ok(servers) => {
+                                    // 保存原始配置；为新出现的 server 默认启用，已有状态保持不变
+                                    let mut states = settings.mcp_server_states.clone();
+                                    for s in &servers {
+                                        states
+                                            .entry(s.name.clone())
+                                            .or_insert(s.is_object && !s.command.is_empty());
+                                    }
+                                    // 清理已不存在的 server 状态
+                                    states
+                                        .retain(|name, _| servers.iter().any(|s| &s.name == name));
+                                    settings.mcp_server_states = states;
+                                    settings.mcp_config_json = settings.mcp_editor_text.clone();
+                                    settings.mcp_editor_error.clear();
+                                    close_after_save = true;
+                                }
+                                Err(e) => {
+                                    settings.mcp_editor_error = e;
+                                }
+                            }
+                        }
+                        if ui.button(i18n::t(i18n::Key::BtnMcpCancel, lang)).clicked() {
+                            close_after_save = true;
+                            settings.mcp_editor_error.clear();
+                        }
+                    });
+                });
+
+            // 中央编辑区：占满剩余空间，文本超长时在编辑区内滚动
+            egui::CentralPanel::default()
+                .frame(egui::Frame::NONE.inner_margin(egui::Margin::symmetric(0, 4)))
+                .show_inside(ui, |ui| {
+                    egui::ScrollArea::vertical()
+                        .id_salt("mcp_editor_scroll")
+                        .auto_shrink(false)
+                        .show(ui, |ui| {
+                            ui.add(
+                                egui::TextEdit::multiline(&mut settings.mcp_editor_text)
+                                    .desired_width(f32::INFINITY)
+                                    .desired_rows(14)
+                                    .font(egui::TextStyle::Monospace),
+                            );
+                        });
+                });
+        });
+    settings.mcp_editor_open = open && !close_after_save;
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod helper;
 pub mod launch_commands_panel;
 pub mod log_panel;
+pub mod mcp_panel;
 pub mod model_panel;
 pub mod params_panel;
 pub mod presets_panel;

--- a/src/ui/settings_panel.rs
+++ b/src/ui/settings_panel.rs
@@ -16,6 +16,7 @@ pub fn ui(
     lang: &i18n::Language,
     show_about: &mut bool,
     debug_mode: &mut bool,
+    updater: &crate::updater::UpdaterHandle,
 ) {
     let accent = crate::theme::accent_color(&settings.accent_color);
 
@@ -216,5 +217,105 @@ pub fn ui(
                 *show_about = true;
             }
         });
+
+        // ── 自更新 ──
+        ui.add_space(8.0);
+        ui.separator();
+        ui.add_space(4.0);
+        let status = updater.snapshot();
+        let busy = matches!(
+            status.state,
+            crate::updater::UpdateState::Checking
+                | crate::updater::UpdateState::Downloading
+                | crate::updater::UpdateState::Installing
+        );
+        ui.horizontal(|ui| {
+            match status.state {
+                crate::updater::UpdateState::Idle
+                | crate::updater::UpdateState::UpToDate
+                | crate::updater::UpdateState::Error(_) => {
+                    if ui
+                        .add_enabled(
+                            !busy,
+                            widgets::rounded_button(i18n::t(i18n::Key::BtnCheckUpdate, lang), None),
+                        )
+                        .clicked()
+                    {
+                        updater.check();
+                    }
+                }
+                crate::updater::UpdateState::Available(_) => {
+                    if ui
+                        .add(widgets::rounded_button(
+                            i18n::t(i18n::Key::BtnInstallUpdate, lang),
+                            None,
+                        ))
+                        .clicked()
+                    {
+                        updater.install();
+                    }
+                }
+                _ => {
+                    // Checking / Downloading / Installing：按钮禁用，靠状态文案展示
+                    ui.add_enabled(
+                        false,
+                        widgets::rounded_button(i18n::t(i18n::Key::BtnCheckUpdate, lang), None),
+                    );
+                }
+            }
+            ui.small(match &status.state {
+                crate::updater::UpdateState::Checking => {
+                    egui::RichText::new(i18n::t(i18n::Key::UpdChecking, lang))
+                }
+                crate::updater::UpdateState::UpToDate => {
+                    egui::RichText::new(i18n::t(i18n::Key::UpdLatest, lang))
+                }
+                crate::updater::UpdateState::Available(v) => {
+                    let text = format!("{} v{}", i18n::t(i18n::Key::UpdAvailable, lang), v);
+                    egui::RichText::new(text).color(ui.visuals().warn_fg_color)
+                }
+                crate::updater::UpdateState::Downloading => {
+                    let pct = if status.total > 0 {
+                        format!(
+                            "{} ({:.0}%)",
+                            i18n::t(i18n::Key::UpdDownloading, lang),
+                            status.done as f64 * 100.0 / status.total as f64
+                        )
+                    } else {
+                        i18n::t(i18n::Key::UpdDownloading, lang).to_string()
+                    };
+                    egui::RichText::new(pct).color(ui.visuals().text_color())
+                }
+                crate::updater::UpdateState::Installing => {
+                    egui::RichText::new(i18n::t(i18n::Key::UpdInstalling, lang))
+                        .color(ui.visuals().warn_fg_color)
+                }
+                crate::updater::UpdateState::Error(msg) => {
+                    if msg == crate::updater::ERR_NETWORK {
+                        egui::RichText::new(i18n::t(i18n::Key::UpdNetworkError, lang))
+                            .color(ui.visuals().error_fg_color)
+                    } else {
+                        egui::RichText::new(format!(
+                            "{}: {}",
+                            i18n::t(i18n::Key::UpdError, lang),
+                            msg
+                        ))
+                        .color(ui.visuals().error_fg_color)
+                    }
+                }
+                crate::updater::UpdateState::Idle => {
+                    egui::RichText::new("").color(ui.visuals().text_color())
+                }
+            });
+        });
+        // 下载进度条
+        if let crate::updater::UpdateState::Downloading = status.state {
+            let frac = if status.total > 0 {
+                (status.done as f64 / status.total as f64).clamp(0.0, 1.0) as f32
+            } else {
+                0.0
+            };
+            ui.add(egui::ProgressBar::new(frac));
+        }
     });
 }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -26,6 +26,7 @@ pub enum NavIcon {
     Rpc,
     Model,
     Params,
+    Mcp,
     Log,
     RpcLog,
     Commands,
@@ -509,6 +510,21 @@ pub fn nav_icon_paint(painter: &Painter, rect: Rect, kind: NavIcon, color: Color
             painter.circle_stroke(top, r, s);
             painter.circle_stroke(bl, r, s);
             painter.circle_stroke(br, r, s);
+        }
+        NavIcon::Mcp => {
+            // ★ MCP 工具集线：左侧小方块（主程序）连接右侧三个工具节点
+            let hub = Rect::from_min_max(Pos2::new(sx(3.0), sy(9.0)), Pos2::new(sx(8.0), sy(15.0)));
+            painter.rect_stroke(hub, 1.5, s, egui::StrokeKind::Middle);
+            let r = w * 0.11;
+            let nodes = [
+                Pos2::new(sx(19.0), sy(4.5)),
+                Pos2::new(sx(21.0), sy(12.0)),
+                Pos2::new(sx(19.0), sy(19.5)),
+            ];
+            for &node in &nodes {
+                painter.line_segment([Pos2::new(sx(8.0), sy(12.0)), node], s);
+                painter.circle_stroke(node, r, s);
+            }
         }
         NavIcon::Model => {
             // ★ HTML: 圆角六边形（3D 盒子 / AI 模型经典图标）

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,0 +1,436 @@
+//! 软件自更新模块（单文件 exe 绿色版）
+//!
+//! 流程：
+//! 1. check()：GET GitHub latest release API（yihuishou/llama.cpp-launcher），
+//!    比对 tag_name 与当前编译版本（CARGO_PKG_VERSION）；
+//! 2. 有新版本时 UI 切换为「安装更新」，install() 后台线程流式下载新 exe
+//!    （写入 exe 同目录 update/ 子目录，带进度 + 取消）；
+//! 3. 下载完成 → replace_and_restart()：以 cmd /d /c 启动分离脚本
+//!    （脚本参数经进程 API 传递，中英文路径均安全）：
+//!      timeout 3 秒（等主进程退出）
+//!      → move 当前 exe → .old
+//!      → move 新 exe → 正式名
+//!      → del .old
+//!      → start 新 exe（自动重启）
+//! 4. 主进程随即退出窗口。
+//!
+//! UI 层：每帧轮询 UpdaterHandle::snapshot() 渲染按钮状态/进度；
+//! 应用关闭时无需额外取消（下载线程持有 Arc 克隆，不阻塞退出）。
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use serde::Deserialize;
+
+/// 上游仓库 latest release API（直连，官方）
+const API_OFFICIAL: &str =
+    "https://api.github.com/repos/yihuishou/llama.cpp-launcher/releases/latest";
+/// API 镜像基址（gh-proxy 前缀，官方超时/失败时自动回退）
+const API_MIRROR: &str =
+    "https://gh-proxy.com/https://api.github.com/repos/yihuishou/llama.cpp-launcher/releases/latest";
+/// 资产下载源（镜像前缀；官方 URL 直接使用 asset.browser_download_url）
+const DOWNLOAD_MIRROR: &str = "https://gh-proxy.com/https://github.com";
+/// 单次网络请求超时（秒）；超时后自动尝试下一个源
+const NETWORK_TIMEOUT_SECS: u64 = 8;
+/// 全部源都失败时 UI 展示的固定错误消息（网络层；区别于业务错误）
+pub const ERR_NETWORK: &str = "network-error";
+/// 请求 User-Agent（GitHub API 必需）
+const USER_AGENT: &str = "llama-cpp-launcher";
+/// 下载块大小（字节）
+const CHUNK_SIZE: usize = 8192;
+
+/// 带超时与 User-Agent 的共享 Agent（在每个源上复用）
+fn agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout(std::time::Duration::from_secs(NETWORK_TIMEOUT_SECS))
+        .build()
+}
+
+// ======================= 公开类型 =======================
+
+/// 更新流程状态（UI 据此渲染按钮与提示）
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UpdateState {
+    /// 空闲（初始 / 已取消）
+    Idle,
+    /// 正在查询 GitHub API
+    Checking,
+    /// 已是最新版本（UI 显示"已是最新"）
+    UpToDate,
+    /// 发现新版本，携带版本号（如 "0.1.20"）
+    Available(String),
+    /// 正在下载更新（进度见 UpdateStatus::done / total）
+    Downloading,
+    /// 下载完成，正在启动自替换（即将重启）
+    Installing,
+    /// 失败，携带英文错误消息（UI 层拼接 i18n 前缀）
+    Error(String),
+}
+
+/// 更新状态快照（UI 每帧轮询）
+#[derive(Clone, Debug)]
+pub struct UpdateStatus {
+    pub state: UpdateState,
+    /// 已下载字节
+    pub done: u64,
+    /// 总字节（未知为 0）
+    pub total: u64,
+}
+
+impl Default for UpdateStatus {
+    fn default() -> Self {
+        Self {
+            state: UpdateState::Idle,
+            done: 0,
+            total: 0,
+        }
+    }
+}
+
+/// 后台更新控制句柄（模式对齐 downloader::DownloadHandle）
+pub struct UpdaterHandle {
+    /// 协作取消标志
+    cancel: Arc<AtomicBool>,
+    /// 共享状态
+    status: Arc<Mutex<UpdateStatus>>,
+    /// worker 线程句柄（线程持有 Arc 克隆，不阻塞应用退出）
+    worker: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl Default for UpdaterHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UpdaterHandle {
+    pub fn new() -> Self {
+        Self {
+            cancel: Arc::new(AtomicBool::new(false)),
+            status: Arc::new(Mutex::new(UpdateStatus::default())),
+            worker: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// 检查更新：仅 Idle / UpToDate / Error 时启动检查线程（防重复）
+    pub fn check(&self) {
+        let busy = matches!(
+            self.status.lock().unwrap().state,
+            UpdateState::Checking | UpdateState::Downloading | UpdateState::Installing
+        );
+        if busy {
+            return;
+        }
+        self.status.lock().unwrap().state = UpdateState::Checking;
+        self.spawn_worker(WorkerKind::Check);
+    }
+
+    /// 开始下载并安装：仅 Available 时启动（Downloading 时忽略）
+    pub fn install(&self) {
+        let ready = matches!(self.status.lock().unwrap().state, UpdateState::Available(_));
+        if !ready {
+            return;
+        }
+        self.cancel.store(false, Ordering::SeqCst);
+        self.spawn_worker(WorkerKind::Download);
+    }
+
+    /// 返回当前状态快照
+    pub fn snapshot(&self) -> UpdateStatus {
+        self.status.lock().unwrap().clone()
+    }
+
+    /// 是否正在下载（UI 禁用按钮用）
+    pub fn is_busy(&self) -> bool {
+        matches!(
+            self.snapshot().state,
+            UpdateState::Checking | UpdateState::Downloading | UpdateState::Installing
+        )
+    }
+
+    /// Drop/关窗调用，协作取消下载
+    pub fn request_cancel(&self) {
+        self.cancel.store(true, Ordering::SeqCst);
+    }
+
+    fn spawn_worker(&self, kind: WorkerKind) {
+        let cancel = Arc::clone(&self.cancel);
+        let status = Arc::clone(&self.status);
+        let handle = thread::spawn(move || match kind {
+            WorkerKind::Check => worker_check(status),
+            WorkerKind::Download => worker_download(cancel, status),
+        });
+        *self.worker.lock().unwrap() = Some(handle);
+    }
+}
+
+enum WorkerKind {
+    Check,
+    Download,
+}
+
+// ======================= GitHub API 类型 =======================
+
+/// GitHub latest release API 响应（只取需要的字段）
+#[derive(Deserialize)]
+struct ReleaseInfo {
+    tag_name: String,
+    assets: Vec<ReleaseAsset>,
+}
+
+#[derive(Deserialize)]
+struct ReleaseAsset {
+    name: String,
+    size: u64,
+    browser_download_url: String,
+}
+
+/// 请求 GitHub latest release API：官方直连失败（超时/网络错误）时自动尝试镜像。
+/// 全部源失败返回 ERR_NETWORK（固定标记，UI 展示"获取失败：网络错误"）。
+fn fetch_release() -> Result<ReleaseInfo, String> {
+    let agent = agent();
+    for url in [API_OFFICIAL, API_MIRROR] {
+        let response = match agent.get(url).set("User-Agent", USER_AGENT).call() {
+            Ok(r) => r,
+            Err(_) => continue, // 该源失败，尝试下一个
+        };
+        let body = match response.into_string() {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if let Ok(info) = serde_json::from_str::<ReleaseInfo>(&body) {
+            return Ok(info);
+        }
+        // 解析失败也视为坏源，继续尝试镜像
+    }
+    Err(ERR_NETWORK.to_string()) // 网络层面：不暴露具体源错误
+}
+
+/// 匹配 Windows exe 资产（llama_cpp_launcher_v*.exe）
+fn pick_launcher_asset(assets: &[ReleaseAsset]) -> Option<&ReleaseAsset> {
+    assets
+        .iter()
+        .find(|a| a.name.starts_with("llama_cpp_launcher_v") && a.name.ends_with(".exe"))
+}
+
+/// 版本号比较："v0.1.20" vs "0.1.19" → 新版本存在（按点分数字比较）
+fn is_newer(tag: &str, current: &str) -> bool {
+    fn nums(s: &str) -> Vec<u64> {
+        s.trim_start_matches('v')
+            .split('.')
+            .filter_map(|p| p.parse::<u64>().ok())
+            .collect()
+    }
+    let t = nums(tag);
+    let c = nums(current);
+    for (a, b) in t.iter().zip(c.iter()) {
+        if a != b {
+            return a > b;
+        }
+    }
+    t.len() > c.len()
+}
+
+// ======================= 检查线程 =======================
+
+fn worker_check(status: Arc<Mutex<UpdateStatus>>) {
+    let current = env!("CARGO_PKG_VERSION");
+    match fetch_release() {
+        Ok(release) => {
+            let mut st = status.lock().unwrap();
+            if is_newer(&release.tag_name, current) {
+                st.state = UpdateState::Available(trim_v(&release.tag_name));
+            } else {
+                st.state = UpdateState::UpToDate;
+            }
+        }
+        Err(message) => {
+            let mut st = status.lock().unwrap();
+            st.state = UpdateState::Error(message);
+        }
+    }
+}
+
+fn trim_v(tag: &str) -> String {
+    tag.trim_start_matches('v').to_string()
+}
+
+// ======================= 下载线程 =======================
+
+fn worker_download(cancel: Arc<AtomicBool>, status: Arc<Mutex<UpdateStatus>>) {
+    let result = run_download(&cancel, &status);
+    match result {
+        Ok(new_exe) => {
+            let mut st = status.lock().unwrap();
+            if cancel.load(Ordering::SeqCst) {
+                st.state = UpdateState::Idle;
+            } else {
+                // 下载完成：启动自替换（拉起的命令行已捕获新 exe 路径）
+                st.state = UpdateState::Installing;
+                st.total = st.done;
+                drop(st);
+                replace_and_restart(&new_exe);
+            }
+        }
+        Err(message) => {
+            let mut st = status.lock().unwrap();
+            if cancel.load(Ordering::SeqCst) {
+                st.state = UpdateState::Idle;
+            } else {
+                st.state = UpdateState::Error(message);
+            }
+        }
+    }
+}
+
+/// 下载新 exe 到 exe 同目录 update/ 子目录；成功返回新 exe 完整路径。
+/// 官方下载源失败（超时/网络错误）时自动尝试镜像；全部失败返回 ERR_NETWORK。
+fn run_download(cancel: &AtomicBool, status: &Arc<Mutex<UpdateStatus>>) -> Result<PathBuf, String> {
+    // 1) 获取 release 信息与资产
+    let release = fetch_release()?;
+    let asset = pick_launcher_asset(&release.assets)
+        .ok_or_else(|| format!("no launcher asset in release {}", release.tag_name))?;
+
+    // 2) 目标目录：exe 同目录/update
+    let exe_path = std::env::current_exe().map_err(|e| e.to_string())?;
+    let exe_dir = exe_path.parent().ok_or("no exe parent dir")?.to_path_buf();
+    let update_dir = exe_dir.join("update");
+    fs::create_dir_all(&update_dir).map_err(|e| format!("create update dir failed: {}", e))?;
+    let new_exe = update_dir.join("llama_cpp_launcher_new.exe");
+
+    // 3) 流式下载（partial + rename 原子落盘）；官方/镜像两源依次尝试
+    {
+        let mut st = status.lock().unwrap();
+        st.state = UpdateState::Downloading;
+        st.done = 0;
+        st.total = asset.size;
+    }
+    let partial = update_dir.join(".partial.new.exe");
+    let agent = agent();
+
+    // asset.browser_download_url 形如 https://github.com/.../releases/download/...
+    // 官方源直接使用；镜像源去掉 github.com 前缀后接在 DOWNLOAD_MIRROR 之后
+    // （DOWNLOAD_MIRROR 以 gh-proxy.com/https://github.com 结尾，不可重复拼接前缀）
+    let official_url = asset.browser_download_url.clone();
+    let mirror_url = match official_url.strip_prefix("https://github.com") {
+        Some(rest) => format!("{}{}", DOWNLOAD_MIRROR, rest),
+        None => official_url.clone(),
+    };
+
+    for url in [official_url, mirror_url] {
+        if cancel.load(Ordering::SeqCst) {
+            return Err("download cancelled".to_string());
+        }
+        let _ = fs::remove_file(&partial); // 上一源失败的残留
+        let response = match agent.get(&url).set("User-Agent", USER_AGENT).call() {
+            Ok(r) => r,
+            Err(_) => continue, // 该源失败，尝试下一个
+        };
+        // 流式写入
+        let result = (|| -> Result<u64, String> {
+            let file =
+                File::create(&partial).map_err(|e| format!("create temp file failed: {}", e))?;
+            let mut writer = BufWriter::new(file);
+            let mut reader = response.into_reader();
+            let mut buf = vec![0u8; CHUNK_SIZE];
+            let mut done: u64 = 0;
+            loop {
+                let n = reader
+                    .read(&mut buf)
+                    .map_err(|e| format!("download failed: {}", e))?;
+                if n == 0 {
+                    break;
+                }
+                writer
+                    .write_all(&buf[..n])
+                    .map_err(|e| format!("write failed: {}", e))?;
+                done += n as u64;
+                status.lock().unwrap().done = done;
+                if cancel.load(Ordering::SeqCst) {
+                    return Err("download cancelled".to_string());
+                }
+            }
+            writer.flush().map_err(|e| e.to_string())?;
+            Ok(done)
+        })();
+        let done = match result {
+            Ok(d) => d,
+            Err(msg) => {
+                if msg == "download cancelled" {
+                    return Err(msg);
+                }
+                continue; // 该源失败，尝试下一个
+            }
+        };
+        if cancel.load(Ordering::SeqCst) {
+            let _ = fs::remove_file(&partial);
+            return Err("download cancelled".to_string());
+        }
+        // 下载完整性校验：实际字节应与资产声明一致
+        if done != asset.size {
+            continue; // 该源数据不完整，尝试下一个
+        }
+        fs::rename(&partial, &new_exe).map_err(|e| format!("rename temp file failed: {}", e))?;
+        return Ok(new_exe);
+    }
+    let _ = fs::remove_file(&partial);
+    Err(ERR_NETWORK.to_string()) // 官方 + 镜像均失败
+}
+
+// ======================= 自替换（Windows） =======================
+
+/// 启动独立 cmd 脚本完成替换并重启：
+///   等待主进程退出 → 当前 exe 改名为 .old → 新 exe 移入正式名 → 删除 .old → 启动新 exe。
+/// 脚本通过进程参数传递（UTF-16），中英文路径均安全；主进程随后自行退出。
+fn replace_and_restart(new_exe: &Path) {
+    let Ok(exe_path) = std::env::current_exe() else {
+        return;
+    };
+    let old_exe = exe_path.with_extension("exe.old");
+    let script = format!(
+        "ping -n 4 127.0.0.1 >nul & \
+         move /Y \"{}\" \"{}\" & \
+         move /Y \"{}\" \"{}\" & \
+         del /Q \"{}\" & \
+         start \"\" \"{}\"",
+        exe_path.display(),
+        old_exe.display(),
+        new_exe.display(),
+        exe_path.display(),
+        old_exe.display(),
+        exe_path.display(),
+    );
+
+    #[cfg(target_os = "windows")]
+    {
+        let mut cmd = std::process::Command::new("cmd");
+        cmd.args(["/d", "/c", &script]);
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            // CREATE_NO_WINDOW | DETACHED_PROCESS
+            cmd.creation_flags(0x0800_0000 | 0x0000_0008);
+        }
+        let _ = cmd.spawn();
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Linux/macOS：sh 后台执行，sleep 等主进程退出后替换并重启
+        let script = format!(
+            "(sleep 3; mv \"{}\" \"{}\"; mv \"{}\" \"{}\"; rm -f \"{}\"; \"{}\" &) >/dev/null 2>&1 &",
+            exe_path.display(),
+            old_exe.display(),
+            new_exe.display(),
+            exe_path.display(),
+            old_exe.display(),
+            exe_path.display(),
+        );
+        let _ = std::process::Command::new("sh")
+            .args(["-c", &script])
+            .spawn();
+    }
+}


### PR DESCRIPTION
## 改动内容

### 一、MCP 管理（新页面，位于"参数"与"服务器日志"之间）

- **MCP 管理页面**：读取已有的 Cursor-compatible `mcpServers` JSON 配置 → 列表展示每个 MCP server（名称 / stdio 命令摘要 / 启用开关）→ 编辑窗口支持粘贴/修改并校验 JSON
- **接入 llama-server**：启动时按启用状态生成 mcp_servers.json（仅包含启用且含 command 的 stdio 条目），自动拼接 `--mcp-servers-config`；无启用条目时不传参
- 依据 llama.cpp 官方 server-mcp.cpp 实际行为：非 stdio（无 command）条目在 UI 明确标注并过滤

### 二、软件自更新（设置-关于页）

- **检查更新**：比对 GitHub Releases 最新版本；官方 API + gh-proxy 镜像自动回退（8 秒超时），全部失败提示"获取失败：网络错误"
- **安装更新**：检测到新版本后按钮变为"安装更新"→ 流式下载新 exe（进度 + 完整性校验）→ 自替换脚本（当前 exe 改名备份 → 移入新 exe → 自动重启）
- 下载隔离在 exe 同目录 update/ 子目录，不污染源码树

### 三、其他

- 日志面板文本选择优化（合并为单一可选中文本区、跨行选择；拖选越过视口边缘自动滚动）
- .gitignore 屏蔽运行时生成文件（mcp_servers.json 等，防配置/密钥误提交）

## 涉及文件

- 新增：src/ui/mcp_panel.rs、src/updater.rs
- 修改：src/config/settings.rs、src/engine/server.rs、src/ui/settings_panel.rs、src/ui/log_panel.rs、src/app.rs、src/ui/widgets.rs、src/ui/mod.rs、src/main.rs、src/i18n.rs、.gitignore

## 验证

- cargo fmt / check / test（27 passed）全通过
- 深浅色模式兼容（全部使用主题色）
- 所有新文本走 i18n（zh/en）